### PR TITLE
Fix about:blank mode persistence and redirect behavior

### DIFF
--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -2806,7 +2806,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 	function applySafetyFeatures(settings) {
 		// About:blank mode
+		console.log("Applying safety features, aboutblankMode:", settings.aboutblankMode);
 		if (settings.aboutblankMode) {
+			console.log("About:blank mode is enabled, triggering enableAboutBlankMode()");
 			enableAboutBlankMode();
 		} else {
 			disableAboutBlankMode();

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -3034,6 +3034,11 @@ body {
 			newTab.document.write(htmlContent);
 			newTab.document.close();
 
+			// Redirect current page to Google after a short delay to ensure about:blank tab loads
+			setTimeout(() => {
+				window.location.href = "https://www.google.com";
+			}, 500);
+
 			// Silent operation - no notifications
 		} else {
 			// Silent failure - no notifications

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -3035,8 +3035,9 @@ body {
 			newTab.document.close();
 
 			// Redirect current page to Google after a short delay to ensure about:blank tab loads
+			// Use replace() to avoid adding proxy to browser history
 			setTimeout(() => {
-				window.location.href = "https://www.google.com";
+				window.location.replace("https://www.google.com");
 			}, 500);
 
 			// Silent operation - no notifications

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -2461,6 +2461,14 @@ document.addEventListener("DOMContentLoaded", () => {
 				// Immediately open about:blank tab when toggled on
 				enableAboutBlankMode();
 			}
+			// Auto-save settings when about:blank mode is toggled
+			saveSettings();
+			showNotification(
+				e.target.checked
+					? "🔒 About:blank mode enabled and saved!"
+					: "🔓 About:blank mode disabled and saved!",
+				"success"
+			);
 		});
 	}
 

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -2453,23 +2453,39 @@ document.addEventListener("DOMContentLoaded", () => {
 	// Load settings on page load
 	loadSettings();
 
-	// Add immediate trigger for about:blank mode
-	const aboutBlankToggle = document.getElementById("aboutblank-mode");
-	if (aboutBlankToggle) {
-		aboutBlankToggle.addEventListener("change", (e) => {
-			if (e.target.checked) {
-				// Immediately open about:blank tab when toggled on
-				enableAboutBlankMode();
-			}
-			// Auto-save settings when about:blank mode is toggled
-			saveSettings();
-			showNotification(
-				e.target.checked
-					? "🔒 About:blank mode enabled and saved!"
-					: "🔓 About:blank mode disabled and saved!",
-				"success"
-			);
-		});
+	// Function to setup about:blank mode toggle
+	function setupAboutBlankToggle() {
+		const aboutBlankToggle = document.getElementById("aboutblank-mode");
+		console.log("Looking for aboutblank-mode element:", aboutBlankToggle);
+
+		if (aboutBlankToggle) {
+			console.log("Found aboutblank-mode element, adding event listener");
+			aboutBlankToggle.addEventListener("change", (e) => {
+				console.log("About:blank toggle changed to:", e.target.checked);
+				if (e.target.checked) {
+					// Immediately open about:blank tab when toggled on
+					enableAboutBlankMode();
+				}
+				// Auto-save settings when about:blank mode is toggled
+				saveSettings();
+				showNotification(
+					e.target.checked
+						? "🔒 About:blank mode enabled and saved!"
+						: "🔓 About:blank mode disabled and saved!",
+					"success"
+				);
+			});
+		} else {
+			console.error("aboutblank-mode element not found!");
+		}
+	}
+
+	// Setup toggle immediately and also after DOM is loaded
+	setupAboutBlankToggle();
+
+	// Also try after DOM is fully loaded in case elements aren't ready yet
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', setupAboutBlankToggle);
 	}
 
 	// Add immediate trigger for anti-GoGuardian mode

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -3907,6 +3907,8 @@ body {
 				defaultSettings.enableWebrtc,
 		};
 
+		console.log("Saving settings:", settings);
+		console.log("About:blank mode being saved:", settings.aboutblankMode);
 		localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
 		localStorage.setItem("vortex_last_backup", new Date().toISOString());
 

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -2459,33 +2459,41 @@ document.addEventListener("DOMContentLoaded", () => {
 		console.log("Looking for aboutblank-mode element:", aboutBlankToggle);
 
 		if (aboutBlankToggle) {
-			console.log("Found aboutblank-mode element, adding event listener");
-			aboutBlankToggle.addEventListener("change", (e) => {
-				console.log("About:blank toggle changed to:", e.target.checked);
-				if (e.target.checked) {
-					// Immediately open about:blank tab when toggled on
-					enableAboutBlankMode();
-				}
-				// Auto-save settings when about:blank mode is toggled
-				saveSettings();
-				showNotification(
-					e.target.checked
-						? "🔒 About:blank mode enabled and saved!"
-						: "🔓 About:blank mode disabled and saved!",
-					"success"
-				);
-			});
+			console.log("Found aboutblank-mode element, checking if listener already attached");
+
+			// Check if event listener already attached to prevent duplicates
+			if (!aboutBlankToggle.hasAttribute('data-listener-attached')) {
+				console.log("Adding event listener to aboutblank-mode");
+				aboutBlankToggle.setAttribute('data-listener-attached', 'true');
+
+				aboutBlankToggle.addEventListener("change", (e) => {
+					console.log("About:blank toggle changed to:", e.target.checked);
+					if (e.target.checked) {
+						// Immediately open about:blank tab when toggled on
+						enableAboutBlankMode();
+					}
+					// Auto-save settings when about:blank mode is toggled
+					saveSettings();
+					showNotification(
+						e.target.checked
+							? "🔒 About:blank mode enabled and saved!"
+							: "🔓 About:blank mode disabled and saved!",
+						"success"
+					);
+				});
+			} else {
+				console.log("Event listener already attached to aboutblank-mode");
+			}
 		} else {
 			console.error("aboutblank-mode element not found!");
 		}
 	}
 
-	// Setup toggle immediately and also after DOM is loaded
-	setupAboutBlankToggle();
-
-	// Also try after DOM is fully loaded in case elements aren't ready yet
+	// Setup toggle with proper timing
 	if (document.readyState === 'loading') {
 		document.addEventListener('DOMContentLoaded', setupAboutBlankToggle);
+	} else {
+		setupAboutBlankToggle();
 	}
 
 	// Add immediate trigger for anti-GoGuardian mode

--- a/mathhomework/public/index.js
+++ b/mathhomework/public/index.js
@@ -944,7 +944,7 @@ document.addEventListener("DOMContentLoaded", () => {
 				copyPasswordBtn.classList.add("success");
 
 				setTimeout(() => {
-					copyPasswordBtn.textContent = "📋 Copy Password";
+					copyPasswordBtn.textContent = "���� Copy Password";
 					copyPasswordBtn.classList.remove("success");
 				}, 2000);
 			} catch (error) {
@@ -2619,6 +2619,9 @@ document.addEventListener("DOMContentLoaded", () => {
 				? JSON.parse(savedSettings)
 				: defaultSettings;
 
+			console.log("Loading settings:", settings);
+			console.log("About:blank mode from saved settings:", settings.aboutblankMode);
+
 			// Apply settings to form elements
 			applySettingsToUI(settings);
 
@@ -3437,7 +3440,7 @@ body {
 		// Add visual indicator that protection is active
 		const indicator = document.createElement("div");
 		indicator.id = "anti-goguardian-indicator";
-		indicator.innerHTML = "🛡��� Protection Active";
+		indicator.innerHTML = "🛡����� Protection Active";
 		indicator.style.cssText = `
 			position: fixed;
 			top: 10px;
@@ -4200,7 +4203,7 @@ body {
 		// Add subtle protection indicator
 		const protectionIndicator = document.createElement("div");
 		protectionIndicator.id = "protection-indicator";
-		protectionIndicator.innerHTML = "🛡️";
+		protectionIndicator.innerHTML = "����️";
 		protectionIndicator.title = "Anti-extension protection active";
 		protectionIndicator.style.cssText = `
 			position: fixed;


### PR DESCRIPTION
## Purpose

The user wanted about:blank mode to persist across browser sessions and automatically redirect the original page to Google when enabled. They encountered issues where:
- Settings weren't being saved when toggling about:blank mode
- Multiple tabs were opening unexpectedly
- The proxy URL was appearing in browser history despite redirects

## Code changes

- **Enhanced about:blank toggle setup**: Added proper event listener management with duplicate prevention using `data-listener-attached` attribute
- **Auto-save functionality**: Settings are now automatically saved when about:blank mode is toggled, with user notifications
- **Google redirect implementation**: Added automatic redirect to Google using `window.location.replace()` to avoid adding proxy URLs to browser history
- **Improved logging**: Added comprehensive console logging for debugging settings persistence and about:blank mode behavior
- **Event listener timing**: Fixed timing issues by properly handling DOM ready states when setting up event listeners

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/34a9619a3bed4e8786f357c614f6b14d/zenith-haven)

👀 [Preview Link](https://34a9619a3bed4e8786f357c614f6b14d-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>34a9619a3bed4e8786f357c614f6b14d</projectId>-->
<!--<branchName>zenith-haven</branchName>-->